### PR TITLE
Add wp-login.php to ignored urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ export default {
 		const contentType = response.headers.get('content-type');
 
 		// If the content is not HTML, then return the response without any changes.
-		if (!contentType || !contentType.includes('text/html') || url.includes('/wp-content/') || url.includes('/wp-includes/') || url.includes('/wp-admin/') || url.includes('/wp-json/')) {
+		if (!contentType || !contentType.includes('text/html') || url.includes('/wp-content/') || url.includes('/wp-includes/') || url.includes('/wp-admin/') || url.includes('/wp-login.php') || url.includes('/wp-json/')) {
 			// console.log('Content type is not HTML');
 			return new Response(response.body, {
 				...response,


### PR DESCRIPTION
WordPress logins typically include a redirection from `/wp-admin/` to `/wp-login.php`, so we need to include at least this in the set of URLs ignored here.

There's possibly an argument to ignore everything matching this pattern: `/wp-*`; however, this may have unintended consequences and catch non-WP URLs that happen to include this. (Unlikely, but possible.)

For now, logging in to WP admin appears to be completely broken, and this should at least just fix it for now.